### PR TITLE
reject the error directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ export class TwitterOAuth {
       this.oauthClient.getOAuthRequestToken(
         (error, oauthRequestToken, oAuthRequestTokenSecret, results) => {
           if (error) {
-            return reject(new Error(error));
+            return reject(error);
           }
 
           if (!results.oauth_callback_confirmed) {


### PR DESCRIPTION
`error` supplied in argument is an instance of class. Not a message string.
So, it throws `[object Object]` in the end.